### PR TITLE
Backend bugfix

### DIFF
--- a/authors/models.py
+++ b/authors/models.py
@@ -7,11 +7,11 @@ class Author(models.Model):
     host = models.URLField(max_length=200, editable=True, blank=True)
     user = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, blank=True, null=True)
     url = models.URLField(max_length=200, editable=False)
-    displayName = models.CharField(max_length=200, blank=True)
+    displayName = models.CharField(max_length=200, blank=True, null=False)
     github = models.URLField(max_length=200, blank=True)
     profileImage = models.URLField(max_length=500, blank=True)
     followers = models.ManyToManyField("self", blank=True, symmetrical=False)
 
-    def save(self, *args, **kwargs):     
+    def save(self, *args, **kwargs):
         self.url = str(self.host) + "authors/" + str(self.id)
         super().save(*args, **kwargs)

--- a/authors/serializers.py
+++ b/authors/serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 from .models import Author
 
 class AuthorDRFSerializer(serializers.ModelSerializer):
+    displayName = serializers.CharField(required=True)
     class Meta:
         model = Author
         fields = ['displayName', 'github', 'profileImage']
@@ -10,7 +11,6 @@ class AuthorSerializer(serializers.ModelSerializer):
     type = serializers.SerializerMethodField()
     id = serializers.SerializerMethodField()
     host = serializers.UUIDField(read_only=True)
-
     class Meta:
         model = Author
         fields = ['type', 'id', 'host', 'url',
@@ -38,12 +38,14 @@ class AuthorsSerializer(serializers.ModelSerializer):
         return 'authors'
 
 class AuthorCreationSerializer(serializers.ModelSerializer):
+    displayName = serializers.CharField(required=True)
     class Meta:
         model = Author
-        fields = ['host', 'user']
+        fields = ['host', 'user', 'displayName', 'github', 'profileImage']
 
 class AuthorRemoteCreationSerializer(serializers.ModelSerializer):
     id = serializers.UUIDField()
+    displayName = serializers.CharField(required=True)
     class Meta:
         model = Author
         fields = ['id', 'host', 'url',
@@ -80,6 +82,7 @@ class AuthorSwaggerRequestSerializer(serializers.ModelSerializer):
     id = serializers.URLField(required=True)
     host = serializers.URLField(required=True)
     url = serializers.URLField(required=True)
+    displayName = serializers.CharField(required=True)
     
     class Meta:
         model = Author

--- a/authors/views.py
+++ b/authors/views.py
@@ -18,7 +18,7 @@ class AuthorView(GenericAPIView):
     
     @swagger_auto_schema(tags=[tag], responses={200: AuthorsSwaggerResponseSerializer})
     def get(self, request):
-        authors = Author.objects.all()
+        authors = Author.objects.exclude(user=None)
         pagination = CustomPagination()
         paginated_authors = pagination.paginate(authors, page=request.GET.get('page'), size=request.GET.get('size'))
         serializer = AuthorsSerializer(paginated_authors)
@@ -55,8 +55,8 @@ class AuthorDetail(GenericAPIView):
             return Response(str(e), status=404)
         except Exception as e:
             return Response(str(e), status=400)
-        serializer = AuthorSerializer(author, data=request.data)
+        serializer = AuthorDRFSerializer(author, data=request.data)
         if serializer.is_valid():
-            serializer.save()
-            return Response(serializer.data, status=200)
+            author = serializer.save()
+            return Response(AuthorSerializer(author).data, status=200)
         return Response(serializer.errors, status=400)

--- a/comments/views.py
+++ b/comments/views.py
@@ -49,10 +49,8 @@ class CommentView(GenericAPIView):
         data.update({"post": pid, "author": aid})
         serializer = CommentCreationSerializer(data=data)
         if serializer.is_valid():
-            serializer.save()
-            comment = Comment.objects.get(pk=serializer.data.get('id'))
-            view_serializer = CommentSerializer(comment)
-            return Response(view_serializer.data, status=201)
+            comment = serializer.save()
+            return Response(CommentSerializer(comment).data, status=201)
         return Response(serializer.errors, status=400)
 
 class CommentIDView(GenericAPIView):

--- a/followRequests/views.py
+++ b/followRequests/views.py
@@ -18,7 +18,7 @@ class FollowRequestDetail(GenericAPIView):
         delete a follow request
         """
         try:
-            follow_request = FollowRequest.objects.get(actor=fid, objects=aid)
+            follow_request = FollowRequest.objects.get(actor=fid, object=aid)
         except FollowRequest.DoesNotExist as e:
             return Response(str(e), status=404)
         except Exception as e:

--- a/followers/views.py
+++ b/followers/views.py
@@ -73,7 +73,7 @@ class FollowerDetailView(GenericAPIView):
             return Response("Successfully added follower", status=201)
         return Response("Follower already exists", status=409)
 
-    @swagger_auto_schema(tags=[tag], responses={204: "", 409: "Follower already exists", 404: "Author cannot be found/Follower cannot be found", 400: "Bad Request"})
+    @swagger_auto_schema(tags=[tag], responses={204: "", 404: "Author cannot be found/Follower cannot be found", 400: "Bad Request"})
     def delete(self, request, aid, fid):
         """
         remove fid as a follower of aid

--- a/inbox/views.py
+++ b/inbox/views.py
@@ -166,7 +166,6 @@ class InboxView(GenericAPIView):
         else:
             return Response("Please enter a valid query parameter", status=400)
         return Response(serializer.data, status=200)
-        
 
     @swagger_auto_schema(tags=[tag], responses={204: "", 400: "Bad Request", 404: "Author cannot be found/Inbox cannot be found" })
     def delete(self, request, aid):

--- a/posts/views.py
+++ b/posts/views.py
@@ -45,10 +45,8 @@ class PostView(GenericAPIView):
         data.update({"author": aid})
         serializer = PostCreationSerializer(data=data)
         if serializer.is_valid():
-            serializer.save()
-            post = Post.objects.get(pk=serializer.data.get('id'))
-            view_serializer = PostSerializer(post)
-            return Response(view_serializer.data, status=201)
+            post = serializer.save()
+            return Response(PostSerializer(post).data, status=201)
         return Response(serializer.errors, status=400)
 
 class PostIDView(GenericAPIView):
@@ -90,10 +88,8 @@ class PostIDView(GenericAPIView):
         data.update({"author": aid, "id": pid})
         serializer = PostCreationWithIDSerializer(data=data)
         if serializer.is_valid():
-            serializer.save()
-            post = Post.objects.get(pk=pid)
-            view_serializer = PostSerializer(post)
-            return Response(view_serializer.data, status=201)
+            post = serializer.save()
+            return Response(PostSerializer(post).data, status=201)
         return Response(serializer.errors, status=400)
         
     @swagger_auto_schema(tags=[tag], request_body=PostsViewSerializer, responses={200: PostSwaggerResponseSerializer, 400: "Bad Request", 404: "Author cannot be found/Post cannot be found"})
@@ -112,10 +108,8 @@ class PostIDView(GenericAPIView):
         data.update({"author": aid, "id": pid})
         serializer = PostCreationSerializer(post, data=data)
         if serializer.is_valid():
-            serializer.save()
-            post = Post.objects.get(pk=serializer.data.get('id'))
-            view_serializer = PostSerializer(post)
-            return Response(view_serializer.data, status=200)
+            post = serializer.save()
+            return Response(PostSerializer(post).data, status=200)
         return Response(serializer.errors, status=400)
 
     @swagger_auto_schema(tags=[tag], responses={204: "", 400: "Bad Request", 404: "Author cannot be found/Post cannot be found"})    

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -20,3 +20,12 @@ class UserCreationSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         if self.is_valid():
             return User.objects.create_user(username=validated_data.get("username"), password=validated_data.get("password"))
+
+class UserRegistrationSwaggerRequestSerializer(serializers.ModelSerializer):
+    profileImage = serializers.URLField(required=False)
+    github = serializers.URLField(required=False)
+    displayName = serializers.CharField(required=True)
+
+    class Meta:
+        model = User
+        fields = ('username', 'password', 'displayName', 'github', 'profileImage')

--- a/users/views.py
+++ b/users/views.py
@@ -6,6 +6,8 @@ from .serializers import UserSerializer, UserCreationSerializer
 from django.contrib.auth.models import User
 from backend.serializers import MyTokenObtainPairSerializer
 from inbox.serializers import InboxCreationSerializer
+from drf_yasg.utils import swagger_auto_schema
+from .serializers import UserRegistrationSwaggerRequestSerializer
 
 def get_tokens_for_user(user):
     refresh = MyTokenObtainPairSerializer().get_token(user)
@@ -29,11 +31,23 @@ class UserCreation(GenericAPIView):
     """
     queryset = User.objects.all()
     serializer_class = UserSerializer
+    tag = "User"
+
+    @swagger_auto_schema(tags=[tag], request_body=UserRegistrationSwaggerRequestSerializer, responses={201: "{'access': 'youraccesstoken', \n'refresh': 'yourrefreshtoken'}"})
     def post(self, request, format=None):
         user_serializer = UserCreationSerializer(data=request.data)
         if user_serializer.is_valid():
             user = user_serializer.save()
-            new_author_data = {"host": request.scheme + "://" + request.get_host() + '/', "user":user.id, }
+            displayName = request.data.get('displayName')
+            profileImage = request.data.get('profileImage')
+            github = request.data.get('github')
+            new_author_data = {"host": request.scheme + "://" + request.get_host() + '/', "user":user.id}
+            if displayName:
+                new_author_data['displayName'] = displayName
+            if profileImage:
+                new_author_data['profileImage'] = profileImage
+            if github:
+                new_author_data['github'] = github
             author_serializer = AuthorCreationSerializer(data=new_author_data)
             if author_serializer.is_valid():
                 author = author_serializer.save()


### PR DESCRIPTION
Bugs:

- Get authors returned all authors from all servers 
- Delete follow request api not working
- Follower swagger doc showed 409 conflict for deleting a follower
- User registration not storing author information due to authenticated endpoint
- Querying again for the same object after serializer.save()

Fixes:

- Get authors now only returns authors from our server
- Fixed delete follow request typo resulting in api not working
- Removed copy and paste error from follower swagger doc
- Now user registration takes in author information to populate the author
- Remove all queries and instead pass the object resulting from serializer.save()